### PR TITLE
Improve chapter metadata and markdown UX

### DIFF
--- a/assets/i18n.js
+++ b/assets/i18n.js
@@ -15,6 +15,11 @@ const dictionaries = {
       notFound: {
         title: 'Chapter not found',
         message: 'We could not find the chapter you were looking for. Try selecting another one from the directory.'
+      },
+      copyCode: {
+        label: 'Copy',
+        success: 'Copied!',
+        error: 'Unable to copy'
       }
     }
   },
@@ -32,6 +37,11 @@ const dictionaries = {
       notFound: {
         title: '未找到章节',
         message: '没有找到请求的章节，请返回目录选择其他章节。'
+      },
+      copyCode: {
+        label: '复制',
+        success: '已复制',
+        error: '复制失败'
       }
     }
   },
@@ -49,6 +59,11 @@ const dictionaries = {
       notFound: {
         title: '找不到章節',
         message: '沒有找到請求的章節，請返回目錄選擇其他章節。'
+      },
+      copyCode: {
+        label: '複製',
+        success: '已複製',
+        error: '複製失敗'
       }
     }
   }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -325,6 +325,11 @@ a.icon-button {
   border-radius: 0 18px 18px 0;
 }
 
+.chapter-body .code-block {
+  position: relative;
+  margin: 1.75rem 0;
+}
+
 .chapter-body pre {
   margin: 1.75rem 0;
   background: var(--code-bg);
@@ -335,6 +340,11 @@ a.icon-button {
   font-family: "JetBrains Mono", "Fira Code", "Cascadia Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   font-size: 0.95rem;
   line-height: 1.7;
+}
+
+.chapter-body .code-block pre {
+  margin: 0;
+  padding-right: 3.6rem;
 }
 
 .chapter-body code {
@@ -354,6 +364,72 @@ a.icon-button {
 .chapter-body pre code.hljs {
   display: block;
   color: inherit;
+}
+
+.chapter-body .code-copy-button {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  color: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  z-index: 1;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chapter-body .code-copy-button:disabled {
+  cursor: wait;
+  opacity: 0.75;
+}
+
+.chapter-body .code-copy-button:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--surface) 100%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  box-shadow: var(--shadow);
+}
+
+.chapter-body .code-copy-button:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.chapter-body .code-copy-button .code-copy-icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.chapter-body .code-copy-button .code-copy-label {
+  line-height: 1;
+}
+
+.chapter-body .code-copy-button.copied {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.chapter-body .code-copy-button.error {
+  background: rgba(220, 38, 38, 0.12);
+  border-color: rgba(220, 38, 38, 0.35);
+  color: #dc2626;
+  box-shadow: none;
+}
+
+body[data-theme="dark"] .chapter-body .code-copy-button.error {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.45);
+  color: #f87171;
 }
 
 body[data-theme="light"] .chapter-body pre code.hljs {


### PR DESCRIPTION
## Summary
- sync the document title and header branding with the localized book title and active chapter
- normalize markdown rendering by converting tabs to four spaces and fixing Lua syntax highlighting
- add a translated code copy button with styling and clipboard support for chapter code blocks

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3a65d26c4832b88b6536379d845d3