### PR TITLE
Refine language selector and chapter UI styling

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -196,6 +196,7 @@ function render(skipUrlUpdate = false) {
     return;
   }
 
+  document.documentElement.lang = state.language;
   dom.brandLink.textContent = languageInfo.bookTitle || dom.brandLink.textContent;
 
   const activeChapter = state.chapterId
@@ -281,19 +282,16 @@ function buildChapterGrid(chapters) {
   const grid = document.createElement('div');
   grid.className = 'chapter-grid';
 
-  chapters.forEach((chapter, index) => {
+  chapters.forEach(chapter => {
     const card = document.createElement('a');
     card.className = 'chapter-card';
     card.href = createChapterUrl(state.language, chapter.id);
     card.dataset.chapterId = chapter.id;
 
-    const label = document.createElement('span');
-    label.textContent = chapterLabel(index, chapter.id);
-
     const strong = document.createElement('strong');
     strong.textContent = chapter.title;
 
-    card.append(label, strong);
+    card.append(strong);
     card.addEventListener('click', event => {
       event.preventDefault();
       state.chapterId = chapter.id;
@@ -318,13 +316,6 @@ function createChapterUrl(language, id) {
   const query = params.toString();
   const base = window.location.pathname.replace(/index\.html$/, '');
   return query ? `${base}?${query}` : base;
-}
-
-function chapterLabel(index, id) {
-  if (id.startsWith('chapter')) {
-    return `#${Number(index).toString().padStart(2, '0')}`;
-  }
-  return '☆';
 }
 
 function renderChapter(languageInfo, skipUrlUpdate = false, chapterOverride = null) {
@@ -478,11 +469,13 @@ function showCopyFeedback(button, message, statusClass) {
 
   labelElement.textContent = message;
   button.setAttribute('aria-label', message);
+  button.setAttribute('title', message);
 
   const defaultLabel = button.dataset.label || message;
   button.__copyResetTimeout = window.setTimeout(() => {
     labelElement.textContent = defaultLabel;
     button.setAttribute('aria-label', defaultLabel);
+    button.setAttribute('title', defaultLabel);
     button.classList.remove('copied', 'error');
     button.__copyResetTimeout = null;
   }, 2000);
@@ -715,11 +708,13 @@ function buildCodeBlock(code, language) {
     'type="button"',
     'class="code-copy-button"',
     `aria-label="${copyLabelAttr}"`,
+    `title="${copyLabelAttr}"`,
     `data-label="${copyLabelAttr}"`,
     `data-success="${copySuccessAttr}"`,
     `data-error="${copyErrorAttr}"`
   ].join(' ');
-  const button = `<button ${buttonAttributes}><span class="code-copy-icon" aria-hidden="true">📋</span><span class="code-copy-label">${escapeHtml(copyLabel)}</span></button>`;
+  const buttonIcon = '<svg class="code-copy-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path></svg>';
+  const button = `<button ${buttonAttributes}>${buttonIcon}<span class="visually-hidden code-copy-label">${escapeHtml(copyLabel)}</span></button>`;
   return `<div class="code-block">${button}<pre><code${classAttr}>${contentHtml}</code></pre></div>`;
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,3 +1,11 @@
+@font-face {
+  font-family: "TsangerJinKai01";
+  src: url("./TsangerJinKai01-W04.woff2") format("woff2");
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+}
+
 :root {
   color-scheme: light dark;
   --bg: #f6f7fb;
@@ -38,12 +46,23 @@ body {
 
 body {
   margin: 0;
-  font-family: "Quicksand", "Inter", "Segoe UI", "Noto Sans SC", "Helvetica Neue", Arial,
-    sans-serif;
+  font-family: "Quicksand", "Inter", "TsangerJinKai01", "Segoe UI", "Noto Sans SC",
+    "Helvetica Neue", Arial, sans-serif;
   background: var(--bg);
   color: var(--text);
   transition: background 0.3s ease, color 0.3s ease;
   -webkit-font-smoothing: antialiased;
+}
+
+body:lang(zh),
+body:lang(zh-cn),
+body:lang(zh-hans),
+body:lang(zh-tw),
+body:lang(zh-hant),
+body:lang(zh-CN),
+body:lang(zh-TW) {
+  font-family: "Quicksand", "TsangerJinKai01", "Inter", "Segoe UI", "Helvetica Neue",
+    Arial, sans-serif;
 }
 
 .visually-hidden {
@@ -90,23 +109,62 @@ body {
   align-items: center;
 }
 
+.control {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
 .control select {
   appearance: none;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 0.5rem 2rem 0.5rem 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  border-radius: 0.9rem;
+  padding: 0.55rem 2.5rem 0.55rem 1rem;
   font-size: 0.95rem;
-  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  font-weight: 500;
+  font-family: inherit;
+  line-height: 1.1;
+  background: color-mix(in srgb, var(--surface) 96%, rgba(255, 255, 255, 0.45));
   color: inherit;
   min-width: 8rem;
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
+    color 0.2s ease;
+}
+
+.control select:hover {
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  background: color-mix(in srgb, var(--surface) 100%, rgba(255, 255, 255, 0.55));
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
 }
 
 .control select:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.control::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  right: 1.15rem;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translateY(-40%) rotate(45deg);
+  opacity: 0.65;
+}
+
+body[data-theme="dark"] .control select {
+  background: color-mix(in srgb, var(--surface) 82%, rgba(15, 23, 42, 0.55));
+  border-color: color-mix(in srgb, var(--border) 55%, transparent);
+}
+
+body[data-theme="dark"] .control select:hover {
+  background: color-mix(in srgb, var(--surface) 90%, rgba(15, 23, 42, 0.35));
+  box-shadow: 0 12px 32px rgba(2, 6, 23, 0.32);
 }
 
 .icon-button {
@@ -214,7 +272,8 @@ a.icon-button {
   color: inherit;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  justify-content: center;
+  min-height: 120px;
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
@@ -225,14 +284,10 @@ a.icon-button {
   border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
 }
 
-.chapter-card span {
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-
 .chapter-card strong {
   font-size: 1.05rem;
   font-weight: 600;
+  line-height: 1.4;
 }
 
 .section-title {
@@ -372,17 +427,18 @@ a.icon-button {
   right: 0.75rem;
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.75rem;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface) 92%, transparent);
-  color: inherit;
-  font-size: 0.75rem;
-  font-weight: 600;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  background: color-mix(in srgb, var(--surface) 96%, transparent);
+  color: var(--muted);
   cursor: pointer;
   z-index: 1;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
+    box-shadow 0.2s ease, transform 0.15s ease;
 }
 
 .chapter-body .code-copy-button:disabled {
@@ -390,9 +446,11 @@ a.icon-button {
   opacity: 0.75;
 }
 
+
 .chapter-body .code-copy-button:hover {
   transform: translateY(-1px);
-  background: color-mix(in srgb, var(--surface) 100%, transparent);
+  color: var(--text);
+  background: color-mix(in srgb, var(--surface) 100%, rgba(255, 255, 255, 0.35));
   border-color: color-mix(in srgb, var(--accent) 45%, transparent);
   box-shadow: var(--shadow);
 }
@@ -400,16 +458,13 @@ a.icon-button {
 .chapter-body .code-copy-button:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
-.chapter-body .code-copy-button .code-copy-icon {
-  font-size: 0.95rem;
-  line-height: 1;
-}
-
-.chapter-body .code-copy-button .code-copy-label {
-  line-height: 1;
+.chapter-body .code-copy-icon {
+  width: 1rem;
+  height: 1rem;
+  fill: currentColor;
 }
 
 .chapter-body .code-copy-button.copied {


### PR DESCRIPTION
## Summary
- drop chapter number badges from the contents grid and center the cards on their titles
- restyle the language selector with a sleeker arrow-only appearance and smooth hover/focus states
- switch the code copy button to a compact icon-only variant with improved feedback handling and hook up the document language for Chinese font usage
- register the TsangerJinKai font locally and update Chinese font stacks to prefer it

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d3af42dffc832ba22f24e82958fcc4