### PR TITLE
Improve dropdown, typography, and reading persistence

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -393,6 +393,11 @@ a.icon-button {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  margin: 2.5rem 0 1.5rem;
+}
+
+.chapters-section > .section-header:first-of-type {
+  margin-top: 0;
 }
 
 .section-header .divider {
@@ -486,8 +491,8 @@ a.icon-button {
   padding: 1.2rem 1.4rem;
   overflow-x: auto;
   font-family: "JetBrains Mono", "Fira Code", "Cascadia Mono", "SFMono-Regular", Consolas,
-    "Liberation Mono", "Menlo", "Courier New", monospace, "TsangerJinKai01", "Source Han Sans SC",
-    "Noto Sans SC", "Microsoft YaHei", sans-serif;
+    "Liberation Mono", "Menlo", "Courier New", "Noto Sans Mono CJK SC", "Source Han Mono SC",
+    "Source Han Sans SC", "Noto Sans SC", "Microsoft YaHei", monospace, sans-serif;
   font-size: 0.95rem;
   line-height: 1.7;
 }
@@ -504,8 +509,8 @@ a.icon-button {
   font-size: 0.92em;
   border: 1px solid color-mix(in srgb, var(--code-border) 80%, transparent);
   font-family: "JetBrains Mono", "Fira Code", "Cascadia Mono", "SFMono-Regular", Consolas,
-    "Liberation Mono", "Menlo", "Courier New", monospace, "TsangerJinKai01", "Source Han Sans SC",
-    "Noto Sans SC", "Microsoft YaHei", sans-serif;
+    "Liberation Mono", "Menlo", "Courier New", "Noto Sans Mono CJK SC", "Source Han Mono SC",
+    "Source Han Sans SC", "Noto Sans SC", "Microsoft YaHei", monospace, sans-serif;
 }
 
 .chapter-body pre code {
@@ -596,13 +601,13 @@ body[data-theme="dark"] .chapter-body pre code.hljs {
 body[data-theme="light"] .chapter-body pre code .hljs-comment,
 body[data-theme="light"] .chapter-body pre code .hljs-quote {
   color: #6a737d;
-  font-style: italic;
+  font-style: normal;
 }
 
 body[data-theme="dark"] .chapter-body pre code .hljs-comment,
 body[data-theme="dark"] .chapter-body pre code .hljs-quote {
   color: #5c6370;
-  font-style: italic;
+  font-style: normal;
 }
 
 body[data-theme="light"] .chapter-body pre code .hljs-keyword {


### PR DESCRIPTION
## Summary
- add managed open/close state with delay for the language dropdown to prevent accidental closure
- persist chapter scroll position when switching languages so readers can resume where they left off
- refine Chinese code font stack, disable italic comments, and adjust section spacing for clearer typography

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3b945087c832b8a532f7b883b7dbe