### PR TITLE
Add C++ highlighting and keyboard navigation improvements

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -630,6 +630,16 @@ body[data-theme="dark"] .chapter-body pre code .hljs-built_in {
   font-weight: 600;
 }
 
+body[data-theme="light"] .chapter-body pre code .hljs-meta {
+  color: #6f42c1;
+  font-weight: 600;
+}
+
+body[data-theme="dark"] .chapter-body pre code .hljs-meta {
+  color: #e5c07b;
+  font-weight: 600;
+}
+
 body[data-theme="light"] .chapter-body pre code .hljs-number {
   color: #005cc5;
 }


### PR DESCRIPTION
## Summary
- add force-closing support to the language dropdown so it collapses on pointer leave
- enable left/right arrow keys to move between chapters when reading and share navigation helpers
- highlight C++ code fences with a dedicated lexer and styling

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3bd017384832ba713941c3e1c6566