### PR TITLE
Fix language dropdown remaining open after selecting an option

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -192,8 +192,6 @@ body:lang(zh-TW) {
   overflow: hidden;
 }
 
-.language-dropdown:hover .language-dropdown__menu,
-.language-dropdown:focus-within .language-dropdown__menu,
 .language-dropdown.is-open .language-dropdown__menu {
   opacity: 1;
   transform: translateY(0);


### PR DESCRIPTION
## Summary
- ensure the language menu visibility is controlled strictly by the JavaScript-managed open state
- remove the :hover/:focus CSS rules so the dropdown closes immediately after a selection

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d3bf7473ac832b9daa017fbdf5fc04